### PR TITLE
Update main.py to make it run

### DIFF
--- a/smeterd/main.py
+++ b/smeterd/main.py
@@ -107,7 +107,7 @@ def add_db_arg(parser):
 
 
 def parse_and_run():
-    from pycli_tools import get_argparser
+    from pycli_tools.parsers import get_argparser
     # create the top-level parser
     parser = get_argparser(prog='smeterd', version=VERSION,
                            default_config=DEFAULT_CONFIG, description=DESC)


### PR DESCRIPTION
without the change:
# /usr/local/bin/smeterd -h

Traceback (most recent call last):
  File "/usr/local/bin/smeterd", line 9, in <module>
    load_entry_point('smeterd==1.7', 'console_scripts', 'smeterd')()
  File "/usr/local/lib/python2.7/site-packages/smeterd/main.py", line 110, in parse_and_run
    from pycli_tools import get_argparser
ImportError: cannot import name get_argparser

With the change no problem to run it. According docs it should be like this
