### PR TITLE
Detect message start (\) and read until end (!) so there is no need t…

### DIFF
--- a/smeterd/meter.py
+++ b/smeterd/meter.py
@@ -69,16 +69,14 @@ class SmartMeter(object):
                 raise SmartMeterError(e)
             else:
                 lines_read += 1
-                if line.startswith('/ISk5'):
-                    if line.endswith('1003'):
-                        max_lines = 13
-                    if line.endswith('1004'):
-                        max_lines = 19
-                    lines = [line]
+		if line.startswith('/'):
+		    startFound = True;
+		    lines = [line];
                 else:
                     lines.append(line)
-                if line.startswith('!') and len(lines) > max_lines:
+                if line.startswith('!') and startFound:
                     complete_packet = True
+		    startFound = False;
                 if len(lines) > max_lines * 2 + 2:
                     raise SmartMeterError('Received %d lines, we seem to be stuck in a loop, quitting.' % len(lines))
             finally:

--- a/smeterd/meter.py
+++ b/smeterd/meter.py
@@ -69,14 +69,14 @@ class SmartMeter(object):
                 raise SmartMeterError(e)
             else:
                 lines_read += 1
-		if line.startswith('/'):
-		    startFound = True;
-		    lines = [line];
+                if line.startswith('/'):
+                    startFound = True;
+                    lines = [line];
                 else:
                     lines.append(line)
                 if line.startswith('!') and startFound:
                     complete_packet = True
-		    startFound = False;
+                    startFound = False;
                 if len(lines) > max_lines * 2 + 2:
                     raise SmartMeterError('Received %d lines, we seem to be stuck in a loop, quitting.' % len(lines))
             finally:

--- a/smeterd/meter.py
+++ b/smeterd/meter.py
@@ -53,6 +53,7 @@ class SmartMeter(object):
         lines = []
         lines_read = 0
         complete_packet = False
+        startFound = False
         max_lines = 35 #largest known telegram has 35 lines
 
         log.info('Start reading lines')


### PR DESCRIPTION
This is to improve message reading and retrun as early as possible, since in some cases you would read up to three messages before you would return the observations from the P1 datagram as can be seen below:

```
me@dev:~/smeterd$ sudo smeterd read-meter --serial-port /dev/ttyAMA0 -vv
[2016-11-21 18:25:50,728] INFO New serial connection opened to /dev/ttyAMA0
[2016-11-21 18:25:50,741] INFO Start reading lines
[2016-11-21 18:25:56,762] DEBUG >> /KMP5 **redacted**
[2016-11-21 18:25:56,770] DEBUG >>
[2016-11-21 18:25:56,818] DEBUG >> 0-0:96.1.1(**redacted**)
[2016-11-21 18:25:56,844] DEBUG >> 1-0:1.8.1(05757.776*kWh)
[2016-11-21 18:25:56,870] DEBUG >> 1-0:1.8.2(04288.571*kWh)
[2016-11-21 18:25:56,895] DEBUG >> 1-0:2.8.1(00000.000*kWh)
[2016-11-21 18:25:56,927] DEBUG >> 1-0:2.8.2(00000.000*kWh)
[2016-11-21 18:25:56,944] DEBUG >> 0-0:96.14.0(0002)
[2016-11-21 18:25:56,969] DEBUG >> 1-0:1.7.0(0000.37*kW)
[2016-11-21 18:25:56,994] DEBUG >> 1-0:2.7.0(0000.00*kW)
[2016-11-21 18:25:57,011] DEBUG >> 0-0:96.13.1()
[2016-11-21 18:25:57,026] DEBUG >> 0-0:96.13.0()
[2016-11-21 18:25:57,037] DEBUG >> 0-1:24.1.0(3)
[2016-11-21 18:25:57,087] DEBUG >> 0-1:96.1.0(**redacted**)
[2016-11-21 18:25:57,144] DEBUG >> 0-1:24.3.0(161121180000)(00)(60)(1)(0-1:24.2.1)(m3)
[2016-11-21 18:25:57,160] DEBUG >> (03136.543)
[2016-11-21 18:25:57,163] DEBUG >> !
[2016-11-21 18:26:07,183] DEBUG >>
[2016-11-21 18:26:07,267] DEBUG >> /KMP5 **redacted**
[2016-11-21 18:26:07,274] DEBUG >>
[2016-11-21 18:26:07,324] DEBUG >> 0-0:96.1.1(**redacted**)
[2016-11-21 18:26:07,349] DEBUG >> 1-0:1.8.1(05757.776*kWh)
[2016-11-21 18:26:07,375] DEBUG >> 1-0:1.8.2(04288.572*kWh)
[2016-11-21 18:26:07,401] DEBUG >> 1-0:2.8.1(00000.000*kWh)
[2016-11-21 18:26:07,432] DEBUG >> 1-0:2.8.2(00000.000*kWh)
[2016-11-21 18:26:07,450] DEBUG >> 0-0:96.14.0(0002)
[2016-11-21 18:26:07,474] DEBUG >> 1-0:1.7.0(0000.36*kW)
[2016-11-21 18:26:07,499] DEBUG >> 1-0:2.7.0(0000.00*kW)
[2016-11-21 18:26:07,515] DEBUG >> 0-0:96.13.1()
[2016-11-21 18:26:07,532] DEBUG >> 0-0:96.13.0()
[2016-11-21 18:26:07,542] DEBUG >> 0-1:24.1.0(3)
[2016-11-21 18:26:07,592] DEBUG >> 0-1:96.1.0(**redacted**)
[2016-11-21 18:26:07,650] DEBUG >> 0-1:24.3.0(161121180000)(00)(60)(1)(0-1:24.2.1)(m3)
[2016-11-21 18:26:07,666] DEBUG >> (03136.543)
[2016-11-21 18:26:07,669] DEBUG >> !
[2016-11-21 18:26:17,683] DEBUG >>
[2016-11-21 18:26:17,756] DEBUG >> /KMP5 **redacted**
[2016-11-21 18:26:17,762] DEBUG >>
[2016-11-21 18:26:17,812] DEBUG >> 0-0:96.1.1(**redacted**)
[2016-11-21 18:26:17,838] DEBUG >> 1-0:1.8.1(05757.776*kWh)
[2016-11-21 18:26:17,864] DEBUG >> 1-0:1.8.2(04288.573*kWh)
[2016-11-21 18:26:17,890] DEBUG >> 1-0:2.8.1(00000.000*kWh)
[2016-11-21 18:26:17,921] DEBUG >> 1-0:2.8.2(00000.000*kWh)
[2016-11-21 18:26:17,938] DEBUG >> 0-0:96.14.0(0002)
[2016-11-21 18:26:17,963] DEBUG >> 1-0:1.7.0(0000.36*kW)
[2016-11-21 18:26:17,988] DEBUG >> 1-0:2.7.0(0000.00*kW)
[2016-11-21 18:26:18,004] DEBUG >> 0-0:96.13.1()
[2016-11-21 18:26:18,020] DEBUG >> 0-0:96.13.0()
[2016-11-21 18:26:18,031] DEBUG >> 0-1:24.1.0(3)
[2016-11-21 18:26:18,081] DEBUG >> 0-1:96.1.0(**redacted**)
[2016-11-21 18:26:18,139] DEBUG >> 0-1:24.3.0(161121180000)(00)(60)(1)(0-1:24.2.1)(m3)
[2016-11-21 18:26:18,154] DEBUG >> (03136.543)
[2016-11-21 18:26:18,157] DEBUG >> !
[2016-11-21 18:26:18,161] INFO Done reading one packet (containing 53 lines)
[2016-11-21 18:26:18,165] DEBUG Total lines read from serial port: 53
[2016-11-21 18:26:18,169] DEBUG Constructing P1Packet from raw data
[2016-11-21 18:26:18,326] INFO Closing connection to `/dev/ttyAMA0`.
Time                      2016-11-21 18:26:18.328698
Total kWh High consumed   4288571
Total kWh Low consumed    5757776
Total gas consumed        3136543
Current kWh tariff        2
me@dev:~/smeterd$
```

After my modifcation you see that it exits after receiving just one datagram:

```
me@dev:~/smeterd$ sudo smeterd read-meter --serial-port /dev/ttyAMA0 -vv
[2016-11-21 18:30:34,881] INFO New serial connection opened to /dev/ttyAMA0
[2016-11-21 18:30:34,891] INFO Start reading lines
[2016-11-21 18:30:40,287] DEBUG >> /KMP5 **redacted**
[2016-11-21 18:30:40,293] DEBUG >>
[2016-11-21 18:30:40,343] DEBUG >> 0-0:96.1.1(**redacted**)
[2016-11-21 18:30:40,369] DEBUG >> 1-0:1.8.1(05757.776*kWh)
[2016-11-21 18:30:40,394] DEBUG >> 1-0:1.8.2(04288.600*kWh)
[2016-11-21 18:30:40,420] DEBUG >> 1-0:2.8.1(00000.000*kWh)
[2016-11-21 18:30:40,452] DEBUG >> 1-0:2.8.2(00000.000*kWh)
[2016-11-21 18:30:40,469] DEBUG >> 0-0:96.14.0(0002)
[2016-11-21 18:30:40,494] DEBUG >> 1-0:1.7.0(0000.36*kW)
[2016-11-21 18:30:40,518] DEBUG >> 1-0:2.7.0(0000.00*kW)
[2016-11-21 18:30:40,535] DEBUG >> 0-0:96.13.1()
[2016-11-21 18:30:40,551] DEBUG >> 0-0:96.13.0()
[2016-11-21 18:30:40,561] DEBUG >> 0-1:24.1.0(3)
[2016-11-21 18:30:40,612] DEBUG >> 0-1:96.1.0(**redacted**)
[2016-11-21 18:30:40,669] DEBUG >> 0-1:24.3.0(161121180000)(00)(60)(1)(0-1:24.2.1)(m3)
[2016-11-21 18:30:40,685] DEBUG >> (03136.543)
[2016-11-21 18:30:40,688] DEBUG >> !
[2016-11-21 18:30:40,692] INFO Done reading one packet (containing 17 lines)
[2016-11-21 18:30:40,696] DEBUG Total lines read from serial port: 17
[2016-11-21 18:30:40,700] DEBUG Constructing P1Packet from raw data
[2016-11-21 18:30:40,850] INFO Closing connection to `/dev/ttyAMA0`.
Time                      2016-11-21 18:30:40.863926
Total kWh High consumed   4288600
Total kWh Low consumed    5757776
Total gas consumed        3136543
Current kWh tariff        2
me@dev:~/smeterd$
```