### PR TITLE
Expose when the gas m3 value was last measured, as a timestamp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 - '3.3'
 - '3.4'
 - '3.5'
+- '3.6'
 notifications:
   email:
     on_success: always

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Read P1 smart meter packets in Python
 installation
 ------------
 
-`smeterd` is fully python 2.7 and python 3.4 compatible.
+`smeterd` is fully python 2.7 up to python 3.6 compatible.
 
 It is highly recommended to use virtualenv for this.
 After having your virtualenv installed and activated run the following command to install

--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,7 @@ Read one packet from your meter using the following command::
     Total kWh Low consumed    546115
     Total gas consumed        963498
     Current kWh tariff        1
+    Gas Measured At           1516562094
 
 
 By default the `read-meter` commands spits out the current date, total kwh1,
@@ -79,15 +80,15 @@ total kwh2, total gas amounts and current kWh tariff on multiple lines.
 You can make it print the same values as a tab seperated list::
 
     $ smeterd read-meter --tsv
-    2013-05-04 22:22:32.224929	331557	199339	749169	1
+    2013-05-04 22:22:32.224929	331557	199339	749169	1	1516562094
 
 
 By piping the output of the `read-meter --tsv` command to a bash script you can fully
 customize what you want to do with the data::
 
     IFS='{tab}'
-    while read date kwh1 kwh2 gas tariff; do
-      mysql my_database -e "INSERT INTO data VALUES ('$date', $kwh1, $kwh2, $gas, $tariff);"
+    while read date kwh1 kwh2 gas tariff gas_measured_at; do
+      mysql my_database -e "INSERT INTO data VALUES ('$date', $kwh1, $kwh2, $gas, $tariff, $gas_measured_at);"
     done < /dev/stdin
 
 

--- a/smeterd/cli/read_meter.py
+++ b/smeterd/cli/read_meter.py
@@ -76,7 +76,8 @@ class ReadMeterCommand(Command):
             ('Total kWh High consumed', int(packet['kwh']['high']['consumed']*1000)),
             ('Total kWh Low consumed', int(packet['kwh']['low']['consumed']*1000)),
             ('Total gas consumed', int(packet['gas']['total']*1000)),
-            ('Current kWh tariff', packet['kwh']['tariff'])
+            ('Current kWh tariff', packet['kwh']['tariff']),
+            ('Gas Measured At', packet['gas']['measured_at']),
         ]
 
         if args.tsv:

--- a/smeterd/meter.py
+++ b/smeterd/meter.py
@@ -1,9 +1,10 @@
 import re
 import logging
 import serial
-import time
-import datetime
 import crcmod.predefined
+
+from time import mktime
+from datetime import datetime
 
 
 log = logging.getLogger(__name__)
@@ -152,7 +153,7 @@ class P1Packet(object):
         measured_at = self.get(b'^(?:0-1:24\.[23]\.[01](?:\((\d+)[SW]?\))?)')
 
         if measured_at:
-            keys['gas']['measured_at'] = int(time.mktime(datetime.datetime.strptime(measured_at, "%y%m%d%H%M%S").timetuple()))
+            keys['gas']['measured_at'] = int(mktime(datetime.strptime(measured_at, "%y%m%d%H%M%S").timetuple()))
         else:
             keys['gas']['measured_at'] = None
 

--- a/smeterd/meter.py
+++ b/smeterd/meter.py
@@ -1,6 +1,8 @@
 import re
 import logging
 import serial
+import time
+import datetime
 import crcmod.predefined
 
 
@@ -146,6 +148,13 @@ class P1Packet(object):
         keys['gas']['device_type'] = self.get_int(b'^0-1:24\.1\.0\((\d)+\)\r\n')
         keys['gas']['total'] = self.get_float(b'^(?:0-1:24\.2\.1(?:\(\d+[SW]\))?)?\(([0-9]{5}\.[0-9]{3})(?:\*m3)?\)\r\n', 0)
         keys['gas']['valve'] = self.get_int(b'^0-1:24\.4\.0\((\d)\)\r\n')
+
+        measured_at = self.get(b'^(?:0-1:24\.[23]\.[01](?:\((\d+)[SW]?\))?)')
+
+        if measured_at:
+            keys['gas']['measured_at'] = int(time.mktime(datetime.datetime.strptime(measured_at, "%y%m%d%H%M%S").timetuple()))
+        else:
+            keys['gas']['measured_at'] = None
 
         keys['msg'] = {}
         keys['msg']['code'] = self.get(b'^0-0:96\.13\.1\((\d+)\)\r\n')

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -34,7 +34,7 @@ def test_default_packet_as_string():
     assert p['msg']['text'] == None
     assert p['gas']['device_type'] == 3
     assert p['gas']['eid'] == '3238303131303031323332313337343132'
-    assert p['gas']['measured_at'] == 1376150400
+    assert p['gas']['measured_at'] == 1376150400, p['gas']['measured_at']
     assert p['gas']['total'] == 947.680
     assert p['gas']['valve'] == 1
     assert p._datagram == NORMAL_PACKET
@@ -57,7 +57,7 @@ def test_default_packet_as_array():
     assert p['msg']['text'] == None
     assert p['gas']['device_type'] == 3
     assert p['gas']['eid'] == '3238303131303031323332313337343132'
-    assert p['gas']['measured_at'] == 1376150400
+    assert p['gas']['measured_at'] == 1376150400, p['gas']['measured_at']
     assert p['gas']['total'] == 947.680
     assert p['gas']['valve'] == 1
     assert p._datagram == NORMAL_PACKET
@@ -80,7 +80,7 @@ def test_BROKEN_PACKET():
     assert p['msg']['text'] == None
     assert p['gas']['device_type'] == 3
     assert p['gas']['eid'] == '3238303131303031323332313337343132'
-    assert p['gas']['measured_at'] == 1376150400
+    assert p['gas']['measured_at'] == 1376150400, p['gas']['measured_at']
     assert p['gas']['total'] == 947.680
     assert p['gas']['valve'] == 1
 
@@ -102,7 +102,7 @@ def test_normal_packet_kaifa1_as_string():
     assert p['msg']['text'] == None
     assert p['gas']['device_type'] == 3
     assert p['gas']['eid'] == '4730303235303033333337343136333136'
-    assert p['gas']['measured_at'] == 1473094800
+    assert p['gas']['measured_at'] == 1473094800, p['gas']['measured_at']
     assert p['gas']['total'] == 323.528
     assert p['gas']['valve'] == None
     assert p._datagram == NORMAL_PACKET_KAIFA1
@@ -125,7 +125,7 @@ def test_normal_packet_kaifa2_as_string():
     assert p['msg']['text'] == None
     assert p['gas']['device_type'] == 3
     assert p['gas']['eid'] == '4730303233353631323139373231393134'
-    assert p['gas']['measured_at'] == 1473019200
+    assert p['gas']['measured_at'] == 1473019200, p['gas']['measured_at']
     assert p['gas']['total'] == 5290.211
     assert p['gas']['valve'] == None
     assert p._datagram == NORMAL_PACKET_KAIFA2
@@ -148,7 +148,7 @@ def test_normal_packet_kaifa3_as_string():
     assert p['msg']['text'] == None
     assert p['gas']['device_type'] == 3
     assert p['gas']['eid'] == '4730303332353631323639323539363136'
-    assert p['gas']['measured_at'] == 1478451600
+    assert p['gas']['measured_at'] == 1478451600, p['gas']['measured_at']
     assert p['gas']['total'] == 230.576
     assert p['gas']['valve'] == None
     assert p._datagram == NORMAL_PACKET_KAIFA3

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -34,6 +34,7 @@ def test_default_packet_as_string():
     assert p['msg']['text'] == None
     assert p['gas']['device_type'] == 3
     assert p['gas']['eid'] == '3238303131303031323332313337343132'
+    assert p['gas']['measured_at'] == 1376150400
     assert p['gas']['total'] == 947.680
     assert p['gas']['valve'] == 1
     assert p._datagram == NORMAL_PACKET
@@ -56,6 +57,7 @@ def test_default_packet_as_array():
     assert p['msg']['text'] == None
     assert p['gas']['device_type'] == 3
     assert p['gas']['eid'] == '3238303131303031323332313337343132'
+    assert p['gas']['measured_at'] == 1376150400
     assert p['gas']['total'] == 947.680
     assert p['gas']['valve'] == 1
     assert p._datagram == NORMAL_PACKET
@@ -78,6 +80,7 @@ def test_BROKEN_PACKET():
     assert p['msg']['text'] == None
     assert p['gas']['device_type'] == 3
     assert p['gas']['eid'] == '3238303131303031323332313337343132'
+    assert p['gas']['measured_at'] == 1376150400
     assert p['gas']['total'] == 947.680
     assert p['gas']['valve'] == 1
 
@@ -99,6 +102,7 @@ def test_normal_packet_kaifa1_as_string():
     assert p['msg']['text'] == None
     assert p['gas']['device_type'] == 3
     assert p['gas']['eid'] == '4730303235303033333337343136333136'
+    assert p['gas']['measured_at'] == 1473094800
     assert p['gas']['total'] == 323.528
     assert p['gas']['valve'] == None
     assert p._datagram == NORMAL_PACKET_KAIFA1
@@ -121,6 +125,7 @@ def test_normal_packet_kaifa2_as_string():
     assert p['msg']['text'] == None
     assert p['gas']['device_type'] == 3
     assert p['gas']['eid'] == '4730303233353631323139373231393134'
+    assert p['gas']['measured_at'] == 1473019200
     assert p['gas']['total'] == 5290.211
     assert p['gas']['valve'] == None
     assert p._datagram == NORMAL_PACKET_KAIFA2
@@ -143,6 +148,7 @@ def test_normal_packet_kaifa3_as_string():
     assert p['msg']['text'] == None
     assert p['gas']['device_type'] == 3
     assert p['gas']['eid'] == '4730303332353631323639323539363136'
+    assert p['gas']['measured_at'] == 1478451600
     assert p['gas']['total'] == 230.576
     assert p['gas']['valve'] == None
     assert p._datagram == NORMAL_PACKET_KAIFA3

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,3 +1,5 @@
+from time import mktime
+from datetime import datetime
 from os.path import join, dirname, realpath
 import sys
 
@@ -34,7 +36,7 @@ def test_default_packet_as_string():
     assert p['msg']['text'] == None
     assert p['gas']['device_type'] == 3
     assert p['gas']['eid'] == '3238303131303031323332313337343132'
-    assert p['gas']['measured_at'] == 1376150400, p['gas']['measured_at']
+    assert p['gas']['measured_at'] == int(mktime(datetime.strptime('130810180000', "%y%m%d%H%M%S").timetuple()))
     assert p['gas']['total'] == 947.680
     assert p['gas']['valve'] == 1
     assert p._datagram == NORMAL_PACKET
@@ -57,7 +59,7 @@ def test_default_packet_as_array():
     assert p['msg']['text'] == None
     assert p['gas']['device_type'] == 3
     assert p['gas']['eid'] == '3238303131303031323332313337343132'
-    assert p['gas']['measured_at'] == 1376150400, p['gas']['measured_at']
+    assert p['gas']['measured_at'] == int(mktime(datetime.strptime('130810180000', "%y%m%d%H%M%S").timetuple()))
     assert p['gas']['total'] == 947.680
     assert p['gas']['valve'] == 1
     assert p._datagram == NORMAL_PACKET
@@ -80,7 +82,7 @@ def test_BROKEN_PACKET():
     assert p['msg']['text'] == None
     assert p['gas']['device_type'] == 3
     assert p['gas']['eid'] == '3238303131303031323332313337343132'
-    assert p['gas']['measured_at'] == 1376150400, p['gas']['measured_at']
+    assert p['gas']['measured_at'] == int(mktime(datetime.strptime('130810180000', "%y%m%d%H%M%S").timetuple()))
     assert p['gas']['total'] == 947.680
     assert p['gas']['valve'] == 1
 
@@ -102,7 +104,7 @@ def test_normal_packet_kaifa1_as_string():
     assert p['msg']['text'] == None
     assert p['gas']['device_type'] == 3
     assert p['gas']['eid'] == '4730303235303033333337343136333136'
-    assert p['gas']['measured_at'] == 1473094800, p['gas']['measured_at']
+    assert p['gas']['measured_at'] == int(mktime(datetime.strptime('160905190000', "%y%m%d%H%M%S").timetuple()))
     assert p['gas']['total'] == 323.528
     assert p['gas']['valve'] == None
     assert p._datagram == NORMAL_PACKET_KAIFA1
@@ -125,7 +127,7 @@ def test_normal_packet_kaifa2_as_string():
     assert p['msg']['text'] == None
     assert p['gas']['device_type'] == 3
     assert p['gas']['eid'] == '4730303233353631323139373231393134'
-    assert p['gas']['measured_at'] == 1473019200, p['gas']['measured_at']
+    assert p['gas']['measured_at'] == int(mktime(datetime.strptime('160904220000', "%y%m%d%H%M%S").timetuple()))
     assert p['gas']['total'] == 5290.211
     assert p['gas']['valve'] == None
     assert p._datagram == NORMAL_PACKET_KAIFA2
@@ -148,7 +150,7 @@ def test_normal_packet_kaifa3_as_string():
     assert p['msg']['text'] == None
     assert p['gas']['device_type'] == 3
     assert p['gas']['eid'] == '4730303332353631323639323539363136'
-    assert p['gas']['measured_at'] == 1478451600, p['gas']['measured_at']
+    assert p['gas']['measured_at'] == int(mktime(datetime.strptime('161106180000', "%y%m%d%H%M%S").timetuple()))
     assert p['gas']['total'] == 230.576
     assert p['gas']['valve'] == None
     assert p._datagram == NORMAL_PACKET_KAIFA3


### PR DESCRIPTION
This PR exposes the timestamp when the gas m3 value was last measured by the smart meter.

Feature requested in issue #19 