### PR TITLE
RTS configuration support

### DIFF
--- a/smeterd/cli/read_meter.py
+++ b/smeterd/cli/read_meter.py
@@ -16,9 +16,10 @@ from smeterd.meter import SmartMeter
 @click.option('--serial-stopbits', help='number of stop bits', default=str(serial.STOPBITS_ONE), type=click.Choice(['1', '1.5', '2']))
 @click.option('--serial-timeout', help='set a read timeout value in seconds', default=10, type=int)
 @click.option('--serial-xonxoff', help='enable software flow control. By default software flow control is disabled', is_flag=True)
+@click.option('--serial-rts', help='Enable RTS flow control.', is_flag=True)
 @click.option('--show-output', help='choose output to display', default=('time', 'consumed', 'tariff', 'gas_measured_at'), multiple=True, type=click.Choice(['time', 'kwh_eid', 'gas_eid', 'consumed', 'tariff', 'gas_measured_at', 'produced', 'current']))
 @click.option('--tsv', help='display packet in tab separated value form', is_flag=True)
-def read_meter(elec_unit, gas_unit, raw, serial_baudrate, serial_bytesize, serial_parity, serial_port, serial_stopbits, serial_timeout, serial_xonxoff, show_output, tsv):
+def read_meter(elec_unit, gas_unit, raw, serial_baudrate, serial_bytesize, serial_parity, serial_port, serial_stopbits, serial_timeout, serial_xonxoff, serial_rts, show_output, tsv):
     '''
     read a single P1 packet to stdout.
 
@@ -38,6 +39,7 @@ def read_meter(elec_unit, gas_unit, raw, serial_baudrate, serial_bytesize, seria
         stopbits=float(serial_stopbits),
         xonxoff=serial_xonxoff,
         timeout=serial_timeout,
+        rts=serial_rts,
     )
 
     with meter:

--- a/smeterd/meter.py
+++ b/smeterd/meter.py
@@ -20,10 +20,15 @@ class SmartMeter(object):
         'xonxoff': False,
         'timeout': 10,
     }
+    serial_rts = False
 
     def __init__(self, port, **kwargs):
         config = {}
         config.update(self.serial_defaults)
+
+        # This is quite uggly. The config part should probably be rewritten.
+        self.serial_rts = kwargs['rts']
+        del kwargs['rts']
         config.update(kwargs)
 
         log.debug('Open serial connect to {} with: {}'.format(port, ', '.join('{}={}'.format(key, value) for key, value in config.items())))
@@ -33,7 +38,7 @@ class SmartMeter(object):
         except (serial.SerialException, OSError) as e:
             raise SmartMeterError(e)
         else:
-            self.serial.setRTS(False)
+            self.serial.setRTS(self.serial_rts)
             self.port = self.serial.name
 
         log.info('New serial connection opened to %s', self.port)
@@ -42,7 +47,7 @@ class SmartMeter(object):
         if not self.serial.isOpen():
             log.info('Opening connection to `%s`', self.serial.name)
             self.serial.open()
-            self.serial.setRTS(False)
+            self.serial.setRTS(self.serial_rts)
         else:
             log.debug('`%s` was already open.', self.serial.name)
 

--- a/smeterd/meter.py
+++ b/smeterd/meter.py
@@ -38,7 +38,7 @@ class SmartMeter(object):
         except (serial.SerialException, OSError) as e:
             raise SmartMeterError(e)
         else:
-            self.serial.setRTS(self.serial_rts)
+            self.serial.rts = self.serial_rts
             self.port = self.serial.name
 
         log.info('New serial connection opened to %s', self.port)
@@ -47,7 +47,7 @@ class SmartMeter(object):
         if not self.serial.isOpen():
             log.info('Opening connection to `%s`', self.serial.name)
             self.serial.open()
-            self.serial.setRTS(self.serial_rts)
+            self.serial.rts = self.serial_rts
         else:
             log.debug('`%s` was already open.', self.serial.name)
 

--- a/smeterd/meter.py
+++ b/smeterd/meter.py
@@ -27,8 +27,9 @@ class SmartMeter(object):
         config.update(self.serial_defaults)
 
         # This is quite uggly. The config part should probably be rewritten.
-        self.serial_rts = kwargs['rts']
-        del kwargs['rts']
+        if 'rts' in kwargs:
+            self.serial_rts = kwargs['rts']
+            del kwargs['rts']
         config.update(kwargs)
 
         log.debug('Open serial connect to {} with: {}'.format(port, ', '.join('{}={}'.format(key, value) for key, value in config.items())))


### PR DESCRIPTION
Not pretty, but it works! :)

Not sure what would be the best approach to have a "nicer" solution actually, but I think this is ok until there are more options outside the `serial_defaults`/PySerial init. 

Also, If we are going to see this repository as a "generic" library for reading any P1 smart meter, maybe we should remove the `serial_defaults` altogether? (pySerial have it's own defaults for all values).
Then every client would have to define its own overrides. Less maintenance here, but this will of course break configuration for existing users.
Maybe something for a "version 2.0"... :) 

fixes https://github.com/nrocco/smeterd/issues/29