### PR TITLE
S34U18 support

### DIFF
--- a/smeterd/cli/read_meter.py
+++ b/smeterd/cli/read_meter.py
@@ -72,10 +72,14 @@ def read_meter(elec_unit, gas_unit, raw, serial_baudrate, serial_bytesize, seria
     if ('gas_eid' in show_output):
         data.append(('Gas serial', packet['gas']['eid']))
     if ('consumed' in show_output):
-        data.extend([
-            ('Total electricity consumed (high, {})'.format(elec_unit), int(packet['kwh']['high']['consumed'] * elec_unit_factor[elec_unit])),
-            ('Total electricity consumed (low, {})'.format(elec_unit), int(packet['kwh']['low']['consumed'] * elec_unit_factor[elec_unit])),
-            ('Total gas consumed ({})'.format(gas_unit), int(packet['gas']['total'] * gas_unit_factor[gas_unit]))])
+        if packet['kwh']['consumed']['total']:
+            data.extend([('Total electricity consumed (total, {})'.format(elec_unit), float(packet['kwh']['consumed']['total'] * elec_unit_factor[elec_unit]))])
+        if packet['kwh']['consumed']['high']:
+            data.extend([('Total electricity consumed (high, {})'.format(elec_unit), float(packet['kwh']['consumed']['high'] * elec_unit_factor[elec_unit]))])
+        if packet['kwh']['consumed']['low']:
+            data.extend([('Total electricity consumed (low, {})'.format(elec_unit), float(packet['kwh']['consumed']['low'] * elec_unit_factor[elec_unit]))])
+        if packet['gas']['total']:
+            data.extent([('Total gas consumed ({})'.format(gas_unit), int(packet['gas']['total'] * gas_unit_factor[gas_unit]))])
     if ('produced' in show_output):
         data.extend([
             ('Total electricity produced (high, {})'.format(elec_unit), int(packet['kwh']['high']['produced'] * elec_unit_factor[elec_unit])),

--- a/smeterd/cli/read_meter.py
+++ b/smeterd/cli/read_meter.py
@@ -16,9 +16,10 @@ from smeterd.meter import SmartMeter
 @click.option('--serial-stopbits', help='number of stop bits', default=str(serial.STOPBITS_ONE), type=click.Choice(['1', '1.5', '2']))
 @click.option('--serial-timeout', help='set a read timeout value in seconds', default=10, type=int)
 @click.option('--serial-xonxoff', help='enable software flow control. By default software flow control is disabled', is_flag=True)
+@click.option('--serial-rts', help='Enable RTS flow control.', is_flag=True)
 @click.option('--show-output', help='choose output to display', default=('time', 'consumed', 'tariff', 'gas_measured_at'), multiple=True, type=click.Choice(['time', 'kwh_eid', 'gas_eid', 'consumed', 'tariff', 'gas_measured_at', 'produced', 'current']))
 @click.option('--tsv', help='display packet in tab separated value form', is_flag=True)
-def read_meter(elec_unit, gas_unit, raw, serial_baudrate, serial_bytesize, serial_parity, serial_port, serial_stopbits, serial_timeout, serial_xonxoff, show_output, tsv):
+def read_meter(elec_unit, gas_unit, raw, serial_baudrate, serial_bytesize, serial_parity, serial_port, serial_stopbits, serial_timeout, serial_xonxoff, serial_rts, show_output, tsv):
     '''
     read a single P1 packet to stdout.
 
@@ -38,6 +39,7 @@ def read_meter(elec_unit, gas_unit, raw, serial_baudrate, serial_bytesize, seria
         stopbits=float(serial_stopbits),
         xonxoff=serial_xonxoff,
         timeout=serial_timeout,
+        rts=serial_rts,
     )
 
     with meter:

--- a/smeterd/meter.py
+++ b/smeterd/meter.py
@@ -6,10 +6,8 @@ import crcmod.predefined
 from time import mktime
 from datetime import datetime
 
-log = logging.getLogger(__name__)
-# Uncomment this line to enable debug logging:
-# logging.basicConfig(level=logging.DEBUG)
 
+log = logging.getLogger(__name__)
 crc16 = crcmod.predefined.mkPredefinedCrcFun('crc16')
 
 
@@ -145,14 +143,14 @@ class P1Packet(object):
         keys['kwh']['consumed'] = {}
         keys['kwh']['consumed']['now']   = self.get_float(rb'^1-0:1\.7\.0\(([0-9]+\.[0-9]+)\*kW\)\r\n')
         keys['kwh']['consumed']['total'] = self.get_float(rb'^1-0:1\.8\.0\(([0-9]+\.[0-9]+)\*kWh\)\r\n')
-        keys['kwh']['consumed']['low']   = self.get_float(rb'^1-0:1\.8\.1\(([0-9]+\.[0-9]+)\*kWh\)\r\n')
-        keys['kwh']['consumed']['high']  = self.get_float(rb'^1-0:1\.8\.2\(([0-9]+\.[0-9]+)\*kWh\)\r\n')
+        keys['kwh']['consumed']['low']   = self.get_float(rb'^1-0:1\.8\.1\(([0-9]+\.[0-9]+)\*kWh\)\r\n') # Tariff 1
+        keys['kwh']['consumed']['high']  = self.get_float(rb'^1-0:1\.8\.2\(([0-9]+\.[0-9]+)\*kWh\)\r\n') # Tariff 2
 
         keys['kwh']['produced'] = {}
         keys['kwh']['produced']['now']   = self.get_float(rb'^1-0:2\.7\.0\(([0-9]+\.[0-9]+)\*kW\)\r\n')
         keys['kwh']['produced']['total'] = self.get_float(rb'^1-0:2\.8\.0\(([0-9]+\.[0-9]+)\*kWh\)\r\n')
-        keys['kwh']['produced']['low']   = self.get_float(rb'^1-0:2\.8\.1\(([0-9]+\.[0-9]+)\*kWh\)\r\n')
-        keys['kwh']['produced']['high']  = self.get_float(rb'^1-0:2\.8\.2\(([0-9]+\.[0-9]+)\*kWh\)\r\n')
+        keys['kwh']['produced']['low']   = self.get_float(rb'^1-0:2\.8\.1\(([0-9]+\.[0-9]+)\*kWh\)\r\n') # Tariff 1
+        keys['kwh']['produced']['high']  = self.get_float(rb'^1-0:2\.8\.2\(([0-9]+\.[0-9]+)\*kWh\)\r\n') # Tariff 2
 
         keys['instantaneous'] = {}
         keys['instantaneous']['l1'] = {}

--- a/smeterd/meter.py
+++ b/smeterd/meter.py
@@ -141,16 +141,16 @@ class P1Packet(object):
         keys['kwh']['treshold'] = self.get_float(rb'^0-0:17\.0\.0\(([0-9]{4}\.[0-9]{2})\*kW\)\r\n')
 
         keys['kwh']['consumed'] = {}
-        keys['kwh']['consumed']['now']   = self.get_float(rb'^1-0:1\.7\.0\(([0-9]+\.[0-9]+)\*kW\)\r\n')
+        keys['kwh']['consumed']['now'] = self.get_float(rb'^1-0:1\.7\.0\(([0-9]+\.[0-9]+)\*kW\)\r\n')
         keys['kwh']['consumed']['total'] = self.get_float(rb'^1-0:1\.8\.0\(([0-9]+\.[0-9]+)\*kWh\)\r\n')
-        keys['kwh']['consumed']['low']   = self.get_float(rb'^1-0:1\.8\.1\(([0-9]+\.[0-9]+)\*kWh\)\r\n') # Tariff 1
-        keys['kwh']['consumed']['high']  = self.get_float(rb'^1-0:1\.8\.2\(([0-9]+\.[0-9]+)\*kWh\)\r\n') # Tariff 2
+        keys['kwh']['consumed']['low'] = self.get_float(rb'^1-0:1\.8\.1\(([0-9]+\.[0-9]+)\*kWh\)\r\n')  # Tariff 1
+        keys['kwh']['consumed']['high'] = self.get_float(rb'^1-0:1\.8\.2\(([0-9]+\.[0-9]+)\*kWh\)\r\n')  # Tariff 2
 
         keys['kwh']['produced'] = {}
-        keys['kwh']['produced']['now']   = self.get_float(rb'^1-0:2\.7\.0\(([0-9]+\.[0-9]+)\*kW\)\r\n')
+        keys['kwh']['produced']['now'] = self.get_float(rb'^1-0:2\.7\.0\(([0-9]+\.[0-9]+)\*kW\)\r\n')
         keys['kwh']['produced']['total'] = self.get_float(rb'^1-0:2\.8\.0\(([0-9]+\.[0-9]+)\*kWh\)\r\n')
-        keys['kwh']['produced']['low']   = self.get_float(rb'^1-0:2\.8\.1\(([0-9]+\.[0-9]+)\*kWh\)\r\n') # Tariff 1
-        keys['kwh']['produced']['high']  = self.get_float(rb'^1-0:2\.8\.2\(([0-9]+\.[0-9]+)\*kWh\)\r\n') # Tariff 2
+        keys['kwh']['produced']['low'] = self.get_float(rb'^1-0:2\.8\.1\(([0-9]+\.[0-9]+)\*kWh\)\r\n')  # Tariff 1
+        keys['kwh']['produced']['high'] = self.get_float(rb'^1-0:2\.8\.2\(([0-9]+\.[0-9]+)\*kWh\)\r\n')  # Tariff 2
 
         keys['instantaneous'] = {}
         keys['instantaneous']['l1'] = {}

--- a/smeterd/meter.py
+++ b/smeterd/meter.py
@@ -20,10 +20,15 @@ class SmartMeter(object):
         'xonxoff': False,
         'timeout': 10,
     }
+    serial_rts = False
 
     def __init__(self, port, **kwargs):
         config = {}
         config.update(self.serial_defaults)
+
+        # This is quite uggly. The config part should probably be rewritten.
+        self.serial_rts = kwargs['rts']
+        del kwargs['rts']
         config.update(kwargs)
 
         log.debug('Open serial connect to {} with: {}'.format(port, ', '.join('{}={}'.format(key, value) for key, value in config.items())))
@@ -33,7 +38,7 @@ class SmartMeter(object):
         except (serial.SerialException, OSError) as e:
             raise SmartMeterError(e)
         else:
-            self.serial.setRTS(False)
+            self.serial.setRTS(self.serial_rts)
             self.port = self.serial.name
 
         log.info('New serial connection opened to %s', self.port)
@@ -42,7 +47,7 @@ class SmartMeter(object):
         if not self.serial.isOpen():
             log.info('Opening connection to `%s`', self.serial.name)
             self.serial.open()
-            self.serial.setRTS(False)
+            self.serial.setRTS(self.serial_rts)
         else:
             log.debug('`%s` was already open.', self.serial.name)
 

--- a/smeterd/meter.py
+++ b/smeterd/meter.py
@@ -163,15 +163,15 @@ class P1Packet(object):
         keys['instantaneous'] = {}
         keys['instantaneous']['l1'] = {}
         keys['instantaneous']['l1']['volts'] = self.get_float(rb'^1-0:32\.7\.0\((\d+\.\d+)\*V\)\r\n')
-        keys['instantaneous']['l1']['amps'] = self.get_int(rb'^1-0:31\.7\.0\((\d+)\*A\)\r\n')
+        keys['instantaneous']['l1']['amps'] = self.get_float(rb'^1-0:31\.7\.0\((\d+\.\d+)\*A\)\r\n')
         keys['instantaneous']['l1']['watts'] = self.get_float(rb'^1-0:21\.7\.0\((\d+\.\d+)\*kW\)\r\n', 0) * 1000
         keys['instantaneous']['l2'] = {}
         keys['instantaneous']['l2']['volts'] = self.get_float(rb'^1-0:52\.7\.0\((\d+\.\d+)\*V\)\r\n')
-        keys['instantaneous']['l2']['amps'] = self.get_int(rb'^1-0:51\.7\.0\((\d+)\*A\)\r\n')
+        keys['instantaneous']['l2']['amps'] = self.get_float(rb'^1-0:51\.7\.0\((\d+\.\d+)\*A\)\r\n')
         keys['instantaneous']['l2']['watts'] = self.get_float(rb'^1-0:41\.7\.0\((\d+\.\d+)\*kW\)\r\n', 0) * 1000
         keys['instantaneous']['l3'] = {}
         keys['instantaneous']['l3']['volts'] = self.get_float(rb'^1-0:72\.7\.0\((\d+\.\d+)\*V\)\r\n')
-        keys['instantaneous']['l3']['amps'] = self.get_int(rb'^1-0:71\.7\.0\((\d+)\*A\)\r\n')
+        keys['instantaneous']['l3']['amps'] = self.get_float(rb'^1-0:71\.7\.0\((\d+\.\d+)\*A\)\r\n')
         keys['instantaneous']['l3']['watts'] = self.get_float(rb'^1-0:61\.7\.0\((\d+\.\d+)\*kW\)\r\n', 0) * 1000
 
         keys['gas'] = {}

--- a/smeterd/meter.py
+++ b/smeterd/meter.py
@@ -38,7 +38,7 @@ class SmartMeter(object):
         except (serial.SerialException, OSError) as e:
             raise SmartMeterError(e)
         else:
-            self.serial.setRTS(self.serial_rts)
+            self.serial.rts = self.serial_rts
             self.port = self.serial.name
 
         log.info('New serial connection opened to %s', self.port)
@@ -47,7 +47,7 @@ class SmartMeter(object):
         if not self.serial.isOpen():
             log.info('Opening connection to `%s`', self.serial.name)
             self.serial.open()
-            self.serial.setRTS(self.serial_rts)
+            self.serial.rts = self.serial_rts
         else:
             log.debug('`%s` was already open.', self.serial.name)
 

--- a/smeterd/meter.py
+++ b/smeterd/meter.py
@@ -27,8 +27,9 @@ class SmartMeter(object):
         config.update(self.serial_defaults)
 
         # This is quite uggly. The config part should probably be rewritten.
-        self.serial_rts = kwargs['rts']
-        del kwargs['rts']
+        if 'rts' in kwargs:
+            self.serial_rts = kwargs['rts']
+            del kwargs['rts']
         config.update(kwargs)
 
         log.debug('Open serial connect to {} with: {}'.format(port, ', '.join('{}={}'.format(key, value) for key, value in config.items())))

--- a/smeterd/meter.py
+++ b/smeterd/meter.py
@@ -6,8 +6,10 @@ import crcmod.predefined
 from time import mktime
 from datetime import datetime
 
-
 log = logging.getLogger(__name__)
+# Uncomment this line to enable debug logging:
+# logging.basicConfig(level=logging.DEBUG)
+
 crc16 = crcmod.predefined.mkPredefinedCrcFun('crc16')
 
 
@@ -138,6 +140,14 @@ class P1Packet(object):
         keys['kwh']['tariff'] = self.get_int(rb'^0-0:96\.14\.0\(([0-9]+)\)\r\n')
         keys['kwh']['switch'] = self.get_int(rb'^0-0:96\.3\.10\((\d)\)\r\n')
         keys['kwh']['treshold'] = self.get_float(rb'^0-0:17\.0\.0\(([0-9]{4}\.[0-9]{2})\*kW\)\r\n')
+
+        keys['kwh']['total_consumed'] = {}
+        keys['kwh']['total_consumed']['active']   = self.get_float(rb'^1-0:1\.8\.0\(([0-9]+\.[0-9]+)\*kWh\)\r\n')
+        keys['kwh']['total_consumed']['reactive'] = self.get_float(rb'^1-0:3\.8\.0\(([0-9]+\.[0-9]+)\*kvarh\)\r\n')
+
+        keys['kwh']['total_input'] = {}
+        keys['kwh']['total_input']['active']   = self.get_float(rb'^1-0:2\.8\.0\(([0-9]+\.[0-9]+)\*kWh\)\r\n')
+        keys['kwh']['total_input']['reactive'] = self.get_float(rb'^1-0:4\.8\.0\(([0-9]+\.[0-9]+)\*kvarh\)\r\n')
 
         keys['kwh']['low'] = {}
         keys['kwh']['low']['consumed'] = self.get_float(rb'^1-0:1\.8\.1\(([0-9]+\.[0-9]+)\*kWh\)\r\n')

--- a/smeterd/meter.py
+++ b/smeterd/meter.py
@@ -142,24 +142,17 @@ class P1Packet(object):
         keys['kwh']['switch'] = self.get_int(rb'^0-0:96\.3\.10\((\d)\)\r\n')
         keys['kwh']['treshold'] = self.get_float(rb'^0-0:17\.0\.0\(([0-9]{4}\.[0-9]{2})\*kW\)\r\n')
 
-        keys['kwh']['total_consumed'] = {}
-        keys['kwh']['total_consumed']['active']   = self.get_float(rb'^1-0:1\.8\.0\(([0-9]+\.[0-9]+)\*kWh\)\r\n')
-        keys['kwh']['total_consumed']['reactive'] = self.get_float(rb'^1-0:3\.8\.0\(([0-9]+\.[0-9]+)\*kvarh\)\r\n')
+        keys['kwh']['consumed'] = {}
+        keys['kwh']['consumed']['now']   = self.get_float(rb'^1-0:1\.7\.0\(([0-9]+\.[0-9]+)\*kW\)\r\n')
+        keys['kwh']['consumed']['total'] = self.get_float(rb'^1-0:1\.8\.0\(([0-9]+\.[0-9]+)\*kWh\)\r\n')
+        keys['kwh']['consumed']['low']   = self.get_float(rb'^1-0:1\.8\.1\(([0-9]+\.[0-9]+)\*kWh\)\r\n')
+        keys['kwh']['consumed']['high']  = self.get_float(rb'^1-0:1\.8\.2\(([0-9]+\.[0-9]+)\*kWh\)\r\n')
 
-        keys['kwh']['total_input'] = {}
-        keys['kwh']['total_input']['active']   = self.get_float(rb'^1-0:2\.8\.0\(([0-9]+\.[0-9]+)\*kWh\)\r\n')
-        keys['kwh']['total_input']['reactive'] = self.get_float(rb'^1-0:4\.8\.0\(([0-9]+\.[0-9]+)\*kvarh\)\r\n')
-
-        keys['kwh']['low'] = {}
-        keys['kwh']['low']['consumed'] = self.get_float(rb'^1-0:1\.8\.1\(([0-9]+\.[0-9]+)\*kWh\)\r\n')
-        keys['kwh']['low']['produced'] = self.get_float(rb'^1-0:2\.8\.1\(([0-9]+\.[0-9]+)\*kWh\)\r\n')
-
-        keys['kwh']['high'] = {}
-        keys['kwh']['high']['consumed'] = self.get_float(rb'^1-0:1\.8\.2\(([0-9]+\.[0-9]+)\*kWh\)\r\n')
-        keys['kwh']['high']['produced'] = self.get_float(rb'^1-0:2\.8\.2\(([0-9]+\.[0-9]+)\*kWh\)\r\n')
-
-        keys['kwh']['current_consumed'] = self.get_float(rb'^1-0:1\.7\.0\(([0-9]+\.[0-9]+)\*kW\)\r\n')
-        keys['kwh']['current_produced'] = self.get_float(rb'^1-0:2\.7\.0\(([0-9]+\.[0-9]+)\*kW\)\r\n')
+        keys['kwh']['produced'] = {}
+        keys['kwh']['produced']['now']   = self.get_float(rb'^1-0:2\.7\.0\(([0-9]+\.[0-9]+)\*kW\)\r\n')
+        keys['kwh']['produced']['total'] = self.get_float(rb'^1-0:2\.8\.0\(([0-9]+\.[0-9]+)\*kWh\)\r\n')
+        keys['kwh']['produced']['low']   = self.get_float(rb'^1-0:2\.8\.1\(([0-9]+\.[0-9]+)\*kWh\)\r\n')
+        keys['kwh']['produced']['high']  = self.get_float(rb'^1-0:2\.8\.2\(([0-9]+\.[0-9]+)\*kWh\)\r\n')
 
         keys['instantaneous'] = {}
         keys['instantaneous']['l1'] = {}


### PR DESCRIPTION
Hi!

So now I finally have a draft with the S34U18 support.  :)

The main issue was that it seems like you are using 2 "tariffs" ( low (1), high (2) ), while my meter is just reporting the "total" (0) value. (In Sweden it seems like most operators are moving towards hourly-prices).
I was actually reading the IEC standard, and it was much clearer on the tariffs:
```
B : C.D.E * F
E – tariff rate 1...8, or 0 for total readings. 
```
https://www.satec-global.com/sites/default/files/EM720-IEC-62056-21.pdf

And the P1 companion standard is actually mentioning that "support for up to sixteen tariffs should be included" (`7. Data objects`).

So I've been refactoring the `keys['kwh']` a bit, making it easier to overview and extend. But this is of course also a breaking change.
If this would not be acceptable, we could still keep the old keys (marked with a "deprecated" comment).

Another thought is if we should rename `low/high` to `t1/t2` or similar, but that could also be done if someone is actually using more then these tariffs.

Another issue was that my `amps` are actually reported as a float. I see that it looks like an int in the P1 companion standard, but using an int feels a bit rough to me. Does your meter really report this as an int?

And just tell me if you want the old kwh keys re-added!

// Emil

fixes #30 