### PR TITLE
Documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,20 +131,20 @@ so you can integrate the reading of P1 packets into your own solutions.
 
 First initiate a new SmartMeter object:
 ```python
-    >>> from smeterd.meter import SmartMeter
-    >>> meter = SmartMeter('/dev/ttyS0')
+from smeterd.meter import SmartMeter
+meter = SmartMeter('/dev/ttyS0')
 ```
 
 Now to read one packet from the meter:
 ```python
-    >>> packet = meter.read_one_packet()
-    >>> print(packet)
-    >>> print(packet['instantaneous']['l1']['volts'])
+packet = meter.read_one_packet()
+print(packet)
+print(packet['instantaneous']['l1']['volts'])
 ```
 
 Do not forget to close the connection to the serial port:
 ```python
-    >>> meter.disconnect()
+meter.disconnect()
 ```
 
 The `SmartMeter.meter.read_one_packet()` function will return an instance of

--- a/README.md
+++ b/README.md
@@ -122,8 +122,6 @@ command line option you will see the raw packet from the smart meter:
     !
 
 
-
-
 usage as a python module
 ------------------------
 
@@ -132,20 +130,22 @@ is quite limited. You can use the `smeterd` package as a regular python module
 so you can integrate the reading of P1 packets into your own solutions.
 
 First initiate a new SmartMeter object:
-
+```python
     >>> from smeterd.meter import SmartMeter
     >>> meter = SmartMeter('/dev/ttyS0')
-
+```
 
 Now to read one packet from the meter:
-
+```python
     >>> packet = meter.read_one_packet()
-    >>> print packet
+    >>> print(packet)
+    >>> print(packet['instantaneous']['l1']['volts'])
+```
 
 Do not forget to close the connection to the serial port:
-
+```python
     >>> meter.disconnect()
-
+```
 
 The `SmartMeter.meter.read_one_packet()` function will return an instance of
 the `smeterd.meter.P1Packet` class.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ smeterd
 
 Read P1 smart meter packets in Python
 
+[Supported meters](supported-meters.md)
 
 installation
 ------------

--- a/README.md
+++ b/README.md
@@ -161,3 +161,11 @@ contribute
 4. Make sure that tests pass (`make test`)
 5. Push to the branch (`git push origin my-new-feature`)
 6. Create new Pull Request
+
+standards
+---------
+
+The P1 port is described in the `P1 companion standard / Dutch Smart Meter Requirements` published by *Netbeheer Nederland* (association of the Netherlands' energy network operators):  
+https://www.netbeheernederland.nl/_upload/Files/Slimme_meter_15_a727fce1f1.pdf
+
+The dataformat is described in `IEC 62056-21 (Electrical metering-Data exchange for meter reading, tariff and load control – Part 21: direct local data exchange, 2002-05)`.

--- a/supported-meters.md
+++ b/supported-meters.md
@@ -1,7 +1,6 @@
 # Overview
 
-All smart meeters with a P1 port should be suppored.  
-This is a list of known supported smart meters and the connection settings, but other meeters should work as well.
+This is a list of known working smart meters and the connection settings, but all meters with a P1 meters should work as well.
 
 ### S34U18
 Used by Vattenfall and several Swedish grid operators.  

--- a/supported-meters.md
+++ b/supported-meters.md
@@ -1,6 +1,6 @@
 # Overview
 
-This is a list of known working smart meters and the connection settings, but all meters with a P1 meters should work as well.
+This is a list of known working smart meters and the connection settings, but all meters with a P1 port should work as well.
 
 ### S34U18
 Used by Vattenfall and several Swedish grid operators.  

--- a/supported-meters.md
+++ b/supported-meters.md
@@ -1,0 +1,11 @@
+# Overview
+
+All smart meeters with a P1 port should be suppored.  
+This is a list of known supported smart meters and the connection settings, but other meeters should work as well.
+
+### S34U18
+Used by Vattenfall and several Swedish grid operators.  
+* Baudrate: 115200  
+* Bytesize: 8
+* Parity: N
+* Stopbits: 1


### PR DESCRIPTION
Making some suggested documentation updates:

* Adding Python syntax highlighting to Readme.md
* Use Python3 syntax in example
* Removing indentation from Python examples to make code easier to copy-paste.
* Adding some words about the standards that are relevant for the P1 port.

Biggest change:
* Adding a "supported-meters" file.

I think this could be very useful for search engine optimisation, if searching for instance "S34U18 python" etc.
But also to list the most commonly used meters.

A future improvement could be to add a library with the most common settings (`SmartMeter(type="s34u18")`), but that might be far away... :)

Comments?

// Emil 